### PR TITLE
Refactor GTM container into modular tags

### DIFF
--- a/gtm_aida_master_template_fix2.json
+++ b/gtm_aida_master_template_fix2.json
@@ -1,6 +1,6 @@
 {
   "exportFormatVersion": 2,
-  "exportTime": "2025-09-24T13:05:41",
+  "exportTime": "2025-09-24T14:04:23",
   "containerVersion": {
     "container": {
       "accountId": "0",
@@ -94,7 +94,7 @@
           {
             "type": "TEMPLATE",
             "key": "value",
-            "value": "000000000"
+            "value": "AW-000000000"
           }
         ]
       },
@@ -141,33 +141,414 @@
             "value": "DES000"
           }
         ]
+      },
+      {
+        "name": "AIDA - Attention Delay (s)",
+        "type": "c",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "value",
+            "value": "5"
+          }
+        ]
+      },
+      {
+        "name": "AIDA - Intention Delay (s)",
+        "type": "c",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "value",
+            "value": "8"
+          }
+        ]
+      },
+      {
+        "name": "AIDA - Desire Min Seconds (s)",
+        "type": "c",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "value",
+            "value": "8"
+          }
+        ]
+      },
+      {
+        "name": "AIDA - Desire Click Threshold",
+        "type": "c",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "value",
+            "value": "3"
+          }
+        ]
       }
     ],
     "trigger": [
       {
+        "triggerId": "1",
+        "name": "All Pages",
+        "type": "PAGEVIEW"
+      },
+      {
+        "triggerId": "2",
         "name": "DOM Ready - All Pages",
-        "type": "DOM_READY",
-        "triggerId": "1"
+        "type": "DOM_READY"
+      },
+      {
+        "triggerId": "3",
+        "name": "AIDA - Attention Event",
+        "type": "CUSTOM_EVENT",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "eventName",
+            "value": "aida_attention_event"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "ignore_case",
+            "value": false
+          }
+        ]
+      },
+      {
+        "triggerId": "4",
+        "name": "AIDA - Intention Event",
+        "type": "CUSTOM_EVENT",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "eventName",
+            "value": "aida_intention_event"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "ignore_case",
+            "value": false
+          }
+        ]
+      },
+      {
+        "triggerId": "5",
+        "name": "AIDA - Desire Event",
+        "type": "CUSTOM_EVENT",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "eventName",
+            "value": "aida_desire_event"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "ignore_case",
+            "value": false
+          }
+        ]
       }
     ],
     "tag": [
       {
-        "name": "AIDA Master - All-in-One (Custom HTML)",
+        "tagId": "1",
+        "name": "AIDA - Session Orchestrator (Custom HTML)",
         "type": "html",
         "parameter": [
           {
             "type": "TEMPLATE",
             "key": "html",
-            "value": "<script>\n/** \n * AIDA Master - All-in-One (v2.3)\n * Attention (5s) → Intention (8s) → Desire (≥8s & ≥3 clicks)\n * Placeholders: GA4 G-000000000 | Ads AW-000000000 (ATT000/INT000/DES000) | Meta 000000000000\n */\n(function() {\n  var CONFIG = { GA4_ID:'G-000000000', ADS_ID:'AW-000000000',\n    ADS_LABELS:{ATT:'ATT000',INT:'INT000',DES:'DES000'}, META_PIXEL_ID:'000000000000' };\n  function nowTs(){return (new Date()).getTime();}\n  function uuid4(){var d=(new Date()).getTime(),d2=(performance&&performance.now&&(performance.now()*1000))||0;\n    return'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){var r=Math.random()*16;\n    if(d>0){r=(d+r)%16|0;d=Math.floor(d/16);}else{r=(d2+r)%16|0;d2=Math.floor(d2/16);}return(c==='x'?r:(r&0x3|0x8)).toString(16);});}\n  function safePush(o){window.dataLayer=window.dataLayer||[];window.dataLayer.push(o);}\n  function secondsSince(ts){return Math.max(0,Math.round((nowTs()-ts)/1000));}\n  if(window.__AIDA_MASTER_INIT__)return; window.__AIDA_MASTER_INIT__=true;\n  window.dataLayer=window.dataLayer||[]; safePush({event:'aida_bootstrap'});\n  (function(){ if(CONFIG.GA4_ID!=='G-000000000'){ if(!window.__gtagLoaded__){\n    window.__gtagLoaded__=true; var s=document.createElement('script'); s.async=true;\n    s.src='https://www.googletagmanager.com/gtag/js?id='+encodeURIComponent(CONFIG.GA4_ID);\n    document.head.appendChild(s); window.dataLayer=window.dataLayer||[];\n    window.gtag=window.gtag||function(){dataLayer.push(arguments);};\n    gtag('js',new Date()); gtag('config',CONFIG.GA4_ID);} } })();\n  (function(){ if(CONFIG.ADS_ID!=='AW-000000000'){\n    window.dataLayer=window.dataLayer||[]; window.gtag=window.gtag||function(){dataLayer.push(arguments);};\n    gtag('config',CONFIG.ADS_ID);} })();\n  (function(){ if(CONFIG.META_PIXEL_ID!=='000000000000'){ if(!window.fbq){\n    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?\n    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;\n    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;\n    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');}\n    if(!window.__fbInited__){window.__fbInited__=true; fbq('init',CONFIG.META_PIXEL_ID,{}, {autoConfig:true});}} })();\n  var SS=window.sessionStorage; try{\n    if(!SS.getItem('aida_session_start_ts'))SS.setItem('aida_session_start_ts',String(nowTs()));\n    if(!SS.getItem('gtm_session_click_count'))SS.setItem('gtm_session_click_count','0');\n    if(!SS.getItem('gtm_aida_stage_reached'))SS.setItem('gtm_aida_stage_reached','None');\n  }catch(e){SS={_m:{},getItem:function(k){return this._m[k];},setItem:function(k,v){this._m[k]=v;},removeItem:function(k){delete this._m[k];}};\n    SS.setItem('aida_session_start_ts',String(nowTs())); SS.setItem('gtm_session_click_count','0'); SS.setItem('gtm_aida_stage_reached','None');}\n  var sessionStart=parseInt(SS.getItem('aida_session_start_ts')||String(nowTs()),10);\n  var stageOrder={'None':0,'Att':1,'Int':2,'De':3}; var timers={t5:false,t8:false}; var eventIdBase=uuid4();\n  function getStage(){return SS.getItem('gtm_aida_stage_reached')||'None';}\n  function setStage(s){try{SS.setItem('gtm_aida_stage_reached',s);}catch(e){}}\n  function getClicks(){return parseInt(SS.getItem('gtm_session_click_count')||'0',10);}\n  function setClicks(n){try{SS.setItem('gtm_session_click_count',String(n));}catch(e){}}\n  function dispatchAll(stage,eid){var payload={event_id:eid,aida_stage:stage,session_clicks:getClicks(),dwell_seconds:secondsSince(sessionStart)};\n    var dl=(stage==='Att'?'aida_attention_event':(stage==='Int'?'aida_intention_event':'aida_desire_event')); safePush(Object.assign({event:dl},payload));\n    if(CONFIG.GA4_ID!=='G-000000000'&&typeof window.gtag==='function'){var n=(stage==='Att'?'aida_attention':(stage==='Int'?'aida_intention':'aida_desire')); gtag('event',n,payload);}\n    if(CONFIG.ADS_ID!=='AW-000000000'&&typeof window.gtag==='function'){var L=(stage==='Att'?CONFIG.ADS_LABELS.ATT:(stage==='Int'?CONFIG.ADS_LABELS.INT:CONFIG.ADS_LABELS.DES));\n      if(L&&!/^0+$/.test(L)){gtag('event','conversion',{'send_to':CONFIG.ADS_ID+'/'+L,'event_id':payload.event_id,'aida_stage':payload.aida_stage,'session_clicks':payload.session_clicks,'dwell_seconds':payload.dwell_seconds});}}\n    if(CONFIG.META_PIXEL_ID!=='000000000000'&&typeof window.fbq==='function'){var m=(stage==='Att'?'AIDA_Attention':(stage==='Int'?'AIDA_Intention':'AIDA_Desire')); fbq('trackCustom',m,payload,{eventID:payload.event_id});}}\n  function maybeFire(target){var cur=getStage(); if(stageOrder[target]>stageOrder[cur]){setStage(target); dispatchAll(target,eventIdBase+'-'+target);}}\n  function checkDesire(){ if(timers.t8 && getClicks()>=3){ maybeFire('De'); } }\n  if(!window.__AIDA_CLICK_BOUND__){window.__AIDA_CLICK_BOUND__=true; document.addEventListener('click',function(){var c=getClicks()+1; setClicks(c); safePush({event:'aida_click_increment',session_clicks:c}); checkDesire();},true);}\n  setTimeout(function(){timers.t5=true; maybeFire('Att');},5000);\n  setTimeout(function(){timers.t8=true; maybeFire('Int'); checkDesire();},8000);\n  document.addEventListener('visibilitychange',function(){ if(!document.hidden) checkDesire(); });\n})();\n</script>"
+            "value": "\n<script>\n(function() {\n  function toNumber(value, fallback) {\n    var num = parseFloat(value);\n    return isFinite(num) ? num : fallback;\n  }\n  var attentionSeconds = Math.max(0, Math.round(toNumber('{{AIDA - Attention Delay (s)}}', 5)));\n  var intentionSeconds = Math.max(attentionSeconds, Math.round(toNumber('{{AIDA - Intention Delay (s)}}', 8)));\n  var desireSeconds = Math.max(intentionSeconds, Math.round(toNumber('{{AIDA - Desire Min Seconds (s)}}', intentionSeconds)));\n  var desireClicks = Math.max(0, Math.round(toNumber('{{AIDA - Desire Click Threshold}}', 3)));\n  if (window.__AIDA_SESSION_INIT__) {\n    return;\n  }\n  window.__AIDA_SESSION_INIT__ = true;\n  var dataLayer = window.dataLayer = window.dataLayer || [];\n  function safePush(obj) {\n    try {\n      dataLayer.push(obj);\n    } catch (e) {}\n  }\n  function nowTs() {\n    return Date.now();\n  }\n  function uuid4() {\n    var d = Date.now();\n    var d2 = (typeof performance !== 'undefined' && performance.now && (performance.now() * 1000)) || 0;\n    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {\n      var r = Math.random() * 16;\n      if (d > 0) {\n        r = (d + r) % 16 | 0;\n        d = Math.floor(d / 16);\n      } else {\n        r = (d2 + r) % 16 | 0;\n        d2 = Math.floor(d2 / 16);\n      }\n      return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);\n    });\n  }\n  function secondsSince(ts) {\n    return Math.max(0, Math.round((nowTs() - ts) / 1000));\n  }\n  var stageOrder = { 'None': 0, 'Att': 1, 'Int': 2, 'De': 3 };\n  var stageEvents = { 'Att': 'aida_attention_event', 'Int': 'aida_intention_event', 'De': 'aida_desire_event' };\n  var storage = window.sessionStorage;\n  try {\n    if (!storage.getItem('aida_session_start_ts')) {\n      storage.setItem('aida_session_start_ts', String(nowTs()));\n    }\n    if (!storage.getItem('gtm_session_click_count')) {\n      storage.setItem('gtm_session_click_count', '0');\n    }\n    if (!storage.getItem('gtm_aida_stage_reached')) {\n      storage.setItem('gtm_aida_stage_reached', 'None');\n    }\n  } catch (err) {\n    storage = {\n      _data: {},\n      getItem: function(key) { return this._data[key]; },\n      setItem: function(key, value) { this._data[key] = String(value); },\n      removeItem: function(key) { delete this._data[key]; }\n    };\n    storage.setItem('aida_session_start_ts', String(nowTs()));\n    storage.setItem('gtm_session_click_count', '0');\n    storage.setItem('gtm_aida_stage_reached', 'None');\n  }\n  var sessionStart = parseInt(storage.getItem('aida_session_start_ts') || String(nowTs()), 10);\n  if (!isFinite(sessionStart)) {\n    sessionStart = nowTs();\n    try {\n      storage.setItem('aida_session_start_ts', String(sessionStart));\n    } catch (e) {}\n  }\n  function getStage() {\n    var stored = storage.getItem('gtm_aida_stage_reached');\n    return stageOrder.hasOwnProperty(stored) ? stored : 'None';\n  }\n  function setStage(stage) {\n    try {\n      storage.setItem('gtm_aida_stage_reached', stage);\n    } catch (e) {}\n  }\n  function getClicks() {\n    var raw = parseInt(storage.getItem('gtm_session_click_count') || '0', 10);\n    return isFinite(raw) && raw >= 0 ? raw : 0;\n  }\n  function setClicks(value) {\n    try {\n      storage.setItem('gtm_session_click_count', String(Math.max(0, value)));\n    } catch (e) {}\n  }\n  var eventIdBase = uuid4();\n  function dispatchStage(stageKey) {\n    var payload = {\n      event_id: eventIdBase + '-' + stageKey,\n      aida_stage: stageKey,\n      session_clicks: getClicks(),\n      dwell_seconds: secondsSince(sessionStart)\n    };\n    safePush({\n      event: stageEvents[stageKey],\n      event_id: payload.event_id,\n      aida_stage: payload.aida_stage,\n      session_clicks: payload.session_clicks,\n      dwell_seconds: payload.dwell_seconds\n    });\n  }\n  function maybeFire(stageKey) {\n    if (!stageEvents[stageKey]) {\n      return;\n    }\n    var currentStage = getStage();\n    if (stageOrder[currentStage] >= stageOrder[stageKey]) {\n      return;\n    }\n    setStage(stageKey);\n    dispatchStage(stageKey);\n  }\n  function checkDesire() {\n    if (stageOrder[getStage()] < stageOrder['Int']) {\n      return;\n    }\n    if (secondsSince(sessionStart) < desireSeconds) {\n      return;\n    }\n    if (getClicks() < desireClicks) {\n      return;\n    }\n    maybeFire('De');\n  }\n  document.addEventListener('click', function() {\n    var total = getClicks() + 1;\n    setClicks(total);\n    safePush({ event: 'aida_click_increment', session_clicks: total });\n    checkDesire();\n  }, true);\n  document.addEventListener('visibilitychange', function() {\n    if (!document.hidden) {\n      checkDesire();\n    }\n  });\n  setTimeout(function() {\n    maybeFire('Att');\n  }, attentionSeconds * 1000);\n  setTimeout(function() {\n    maybeFire('Int');\n    checkDesire();\n  }, intentionSeconds * 1000);\n  setTimeout(function() {\n    checkDesire();\n  }, desireSeconds * 1000);\n  safePush({\n    event: 'aida_bootstrap',\n    aida_stage: getStage(),\n    session_clicks: getClicks(),\n    dwell_seconds: secondsSince(sessionStart),\n    aida_attention_delay_s: attentionSeconds,\n    aida_intention_delay_s: intentionSeconds,\n    aida_desire_delay_s: desireSeconds,\n    aida_desire_click_threshold: desireClicks\n  });\n})();\n</script>\n"
           },
           {
             "type": "BOOLEAN",
             "key": "supportDocumentWrite",
             "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "2"
+        ]
+      },
+      {
+        "tagId": "2",
+        "name": "AIDA - gtag Loader (GA4 + Ads)",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var ga4Id = '{{GA4 Measurement ID}}';\n  var adsId = '{{Google Ads Conversion ID}}';\n  var hasGa4 = ga4Id && ga4Id !== 'G-000000000';\n  var hasAds = adsId && adsId !== 'AW-000000000';\n  if (!hasGa4 && !hasAds) {\n    return;\n  }\n  var scriptId = hasGa4 ? ga4Id : adsId;\n  if (!window.gtag) {\n    window.dataLayer = window.dataLayer || [];\n    window.gtag = function(){ window.dataLayer.push(arguments); };\n  }\n  if (!window.__AIDA_GTAG_SCRIPT__ && scriptId) {\n    window.__AIDA_GTAG_SCRIPT__ = true;\n    var gtagScript = document.createElement('script');\n    gtagScript.async = true;\n    gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(scriptId);\n    var firstScript = document.getElementsByTagName('script')[0];\n    (firstScript && firstScript.parentNode ? firstScript.parentNode : document.head || document.documentElement).insertBefore(gtagScript, firstScript || null);\n  }\n  window.gtag('js', new Date());\n  if (hasGa4) {\n    window.gtag('config', ga4Id, { 'send_page_view': false });\n  }\n  if (hasAds) {\n    window.gtag('config', adsId);\n  }\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
           }
         ],
         "firingTriggerId": [
           "1"
+        ]
+      },
+      {
+        "tagId": "3",
+        "name": "AIDA - GA4 Event - Attention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'aida_attention', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "3"
+        ]
+      },
+      {
+        "tagId": "4",
+        "name": "AIDA - GA4 Event - Intention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'aida_intention', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "4"
+        ]
+      },
+      {
+        "tagId": "5",
+        "name": "AIDA - GA4 Event - Desire",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'aida_desire', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "5"
+        ]
+      },
+      {
+        "tagId": "6",
+        "name": "AIDA - Google Ads Conversion - Attention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var adsId = '{{Google Ads Conversion ID}}';\n  var label = '{{Ads Label - ATT}}';\n  if (!adsId || adsId === 'AW-000000000' || !label || label === 'ATT000' || label === 'INT000' || label === 'DES000') {\n    return;\n  }\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    send_to: adsId + '/' + label,\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'conversion', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "3"
+        ]
+      },
+      {
+        "tagId": "7",
+        "name": "AIDA - Google Ads Conversion - Intention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var adsId = '{{Google Ads Conversion ID}}';\n  var label = '{{Ads Label - INT}}';\n  if (!adsId || adsId === 'AW-000000000' || !label || label === 'ATT000' || label === 'INT000' || label === 'DES000') {\n    return;\n  }\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    send_to: adsId + '/' + label,\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'conversion', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "4"
+        ]
+      },
+      {
+        "tagId": "8",
+        "name": "AIDA - Google Ads Conversion - Desire",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var adsId = '{{Google Ads Conversion ID}}';\n  var label = '{{Ads Label - DES}}';\n  if (!adsId || adsId === 'AW-000000000' || !label || label === 'ATT000' || label === 'INT000' || label === 'DES000') {\n    return;\n  }\n  if (typeof window.gtag !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    send_to: adsId + '/' + label,\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  window.gtag('event', 'conversion', payload);\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "5"
+        ]
+      },
+      {
+        "tagId": "9",
+        "name": "Meta Pixel - Base",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var pixelId = '{{Meta Pixel ID}}';\n  if (!pixelId || /^0+$/.test(pixelId)) {\n    return;\n  }\n  if (window.fbq) {\n    return;\n  }\n  window.fbq = function(){\n    window.fbq.callMethod ? window.fbq.callMethod.apply(window.fbq, arguments) : window.fbq.queue.push(arguments);\n  };\n  if (!window._fbq) {\n    window._fbq = window.fbq;\n  }\n  window.fbq.push = window.fbq;\n  window.fbq.loaded = true;\n  window.fbq.version = '2.0';\n  window.fbq.queue = [];\n  var script = document.createElement('script');\n  script.async = true;\n  script.src = 'https://connect.facebook.net/en_US/fbevents.js';\n  var firstScript = document.getElementsByTagName('script')[0];\n  (firstScript && firstScript.parentNode ? firstScript.parentNode : document.head || document.documentElement).insertBefore(script, firstScript || null);\n  window.fbq('init', pixelId);\n  window.fbq('track', 'PageView');\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "1"
+        ]
+      },
+      {
+        "tagId": "10",
+        "name": "Meta Pixel - AIDA Attention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var pixelId = '{{Meta Pixel ID}}';\n  if (!pixelId || /^0+$/.test(pixelId)) {\n    return;\n  }\n  if (typeof window.fbq !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  var options = eventId ? { eventID: eventId } : undefined;\n  if (options) {\n    window.fbq('trackCustom', 'AIDA_Attention', payload, options);\n  } else {\n    window.fbq('trackCustom', 'AIDA_Attention', payload);\n  }\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "3"
+        ]
+      },
+      {
+        "tagId": "11",
+        "name": "Meta Pixel - AIDA Intention",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var pixelId = '{{Meta Pixel ID}}';\n  if (!pixelId || /^0+$/.test(pixelId)) {\n    return;\n  }\n  if (typeof window.fbq !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  var options = eventId ? { eventID: eventId } : undefined;\n  if (options) {\n    window.fbq('trackCustom', 'AIDA_Intention', payload, options);\n  } else {\n    window.fbq('trackCustom', 'AIDA_Intention', payload);\n  }\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "4"
+        ]
+      },
+      {
+        "tagId": "12",
+        "name": "Meta Pixel - AIDA Desire",
+        "type": "html",
+        "parameter": [
+          {
+            "type": "TEMPLATE",
+            "key": "html",
+            "value": "\n<script>\n(function() {\n  var pixelId = '{{Meta Pixel ID}}';\n  if (!pixelId || /^0+$/.test(pixelId)) {\n    return;\n  }\n  if (typeof window.fbq !== 'function') {\n    return;\n  }\n  var eventId = '{{DLV - event_id}}';\n  if (!eventId) {\n    return;\n  }\n  var stage = '{{DLV - aida_stage}}';\n  var clicks = parseInt('{{DLV - session_clicks}}', 10);\n  var dwell = parseFloat('{{DLV - dwell_seconds}}');\n  var payload = {\n    event_id: eventId,\n    aida_stage: stage\n  };\n  if (!isNaN(clicks)) {\n    payload.session_clicks = clicks;\n  }\n  if (!isNaN(dwell)) {\n    payload.dwell_seconds = dwell;\n  }\n  var options = eventId ? { eventID: eventId } : undefined;\n  if (options) {\n    window.fbq('trackCustom', 'AIDA_Desire', payload, options);\n  } else {\n    window.fbq('trackCustom', 'AIDA_Desire', payload);\n  }\n})();\n</script>\n"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "supportDocumentWrite",
+            "value": false
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "useIframe",
+            "value": false
+          }
+        ],
+        "firingTriggerId": [
+          "5"
         ]
       }
     ],


### PR DESCRIPTION
## Summary
- add adjustable AIDA timing variables and custom event triggers to the container
- replace the monolithic custom HTML tag with a session orchestrator plus GA4, Google Ads, and Meta Pixel tags that read shared data layer variables
- add a shared gtag loader so GA4 and Ads conversions rely on configured IDs instead of hard-coded placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f4ace08c8332994b0764a1a3ca40